### PR TITLE
Add error tracing with sentry

### DIFF
--- a/cmd/gitformer/root.go
+++ b/cmd/gitformer/root.go
@@ -7,6 +7,7 @@ package gitformer
 import (
 	"os"
 
+	"github.com/peachpielabs/gitformer/pkg/playbook"
 	"github.com/spf13/cobra"
 )
 
@@ -40,6 +41,7 @@ For more information, view the docs at https://github.com/peachpielabs/gitformer
 func Execute() {
 	err := rootCmd.Execute()
 	if err != nil {
+		playbook.CaptureError(err)
 		os.Exit(1)
 	}
 }

--- a/main.go
+++ b/main.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/getsentry/sentry-go"
 	"github.com/peachpielabs/gitformer/cmd/gitformer"
+	"github.com/peachpielabs/gitformer/pkg/playbook"
 )
 
 var version = "No release version provided"
@@ -40,6 +41,7 @@ func main() {
 		Release:          version,
 	})
 	if err != nil {
+		playbook.CaptureError(err)
 		log.Fatalf("sentry.Init: %s", err)
 	}
 	// Flush buffered events before the program terminates.

--- a/pkg/playbook/playbook.go
+++ b/pkg/playbook/playbook.go
@@ -15,6 +15,7 @@ import (
 	"path"
 	"path/filepath"
 
+	"github.com/getsentry/sentry-go"
 	"gopkg.in/yaml.v2"
 )
 
@@ -41,26 +42,32 @@ type Output struct {
 	OutputFile   string `yaml:"outputFile,omitempty"`
 }
 
+func CaptureError(err error) {
+	if os.Getenv("GITFORMER_TELEMETRY_DISABLED") != "true" {
+		sentry.CaptureException(err)
+	}
+}
+
 func LoadYAMLFile(file_path string) (Playbook, error) {
 
 	// Open our yamlFile
 	yamlFile, err := os.Open(file_path)
 	if err != nil {
-		log.Fatal(err)
+		return Playbook{}, err
 	}
 	defer yamlFile.Close()
 
 	// Read the file into a byte array
 	byteValue, err := io.ReadAll(yamlFile)
 	if err != nil {
-		log.Fatal(err)
+		return Playbook{}, err
 	}
 
 	// Unmarshal the yaml into a Playbook struct
 	var playbook Playbook
 	err = yaml.Unmarshal(byteValue, &playbook)
 	if err != nil {
-		log.Fatal(err)
+		return Playbook{}, err
 	}
 
 	return playbook, err
@@ -119,9 +126,9 @@ func RenderTemplate(playbook_base_dir string, input_data map[string]interface{},
 	template_filepath = playbook_base_dir + "/" + template_filepath
 	filenameTemplate := template.Must(template.New("filename").Parse(output_filepath))
 	var fileTpl bytes.Buffer
-	err1 := filenameTemplate.Execute(&fileTpl, input_data)
-	if err1 != nil {
-		panic(err1)
+	err := filenameTemplate.Execute(&fileTpl, input_data)
+	if err != nil {
+		return err
 	}
 	outputFilePath := playbook_base_dir + "/" + fileTpl.String()
 	outputDir := path.Dir(outputFilePath)
@@ -129,12 +136,12 @@ func RenderTemplate(playbook_base_dir string, input_data map[string]interface{},
 
 	tmpl, err := template.New(filepath.Base(template_filepath)).ParseFiles(template_filepath)
 	if err != nil {
-		panic(err)
+		return err
 	}
 	var tpl bytes.Buffer
 	err = tmpl.Execute(&tpl, input_data)
 	if err != nil {
-		panic(err)
+		return err
 	}
 	renderedFileContents := tpl.String()
 
@@ -142,18 +149,19 @@ func RenderTemplate(playbook_base_dir string, input_data map[string]interface{},
 	err = os.MkdirAll(outputDir, os.ModePerm)
 	if err != nil {
 		log.Println(err)
+		return err
 	}
 
 	// write renderedFileContents to the output file
 	f, err := os.Create(outputFilePath)
 	if err != nil {
-		panic(err)
+		return err
 	}
 	defer f.Close()
 
 	_, err = f.WriteString(renderedFileContents)
 	if err != nil {
-		panic(err)
+		return err
 	}
 
 	fmt.Printf("Template rendered successfully to %v\n", outputFilePath)


### PR DESCRIPTION
- Implement exception tracking with Sentry:
      - Sign up for a free developer account with sentry
      - For each error that we catch in GitFormer, also report the exception/error to Sentry
      - Enable user to disable error reporting to sentry by setting an environment variable GITFORMER_TELEMETRY_DISABLED=true